### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM rust:bookworm AS builder
 
-WORKDIR /usr/src/passes
+WORKDIR /src
 COPY . .
-RUN cargo install --path .
+RUN cargo build --release
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y libssl-dev
+RUN apt-get update && apt-get install -y libssl3 && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/local/cargo/bin/passes /usr/local/bin/passes
+COPY --from=builder /src/target/release/passes /usr/local/bin/passes
 COPY ./Event.pass /usr/local/bin/Event.pass
 
-CMD ["passes"]
+ENTRYPOINT ["/usr/local/bin/passes"]


### PR DESCRIPTION
- Use `cargo build` to ensure lockfile is used
- Install `libssl3` without development files
- Use entrypoint to avoid shell invocation