### PR TITLE
Explicitly install clippy and rustfmt in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Setup Rust
-        run: rustup update stable && rustup default stable
+        run: >
+          rustup update stable &&
+          rustup default stable &&
+          rustup component add --toolchain stable clippy rustfmt      
       - name: Cargo cache
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
       - name: Check clippy


### PR DESCRIPTION
Explicitly install clippy and rustfmt in CI, which seem to be missing in recent GitHub Actions runner images.